### PR TITLE
Configure nextjs for vercel with ci/cd guardrails

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,0 +1,7 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+	reactStrictMode: true,
+	// If you need custom headers, define them here (not in vercel.json):
+	// async headers() { return [{ source: '/(.*)', headers: [{ key: 'X-Council-Validated', value: 'true' }, { key: 'X-Brand-Compliant', value: 'luxury' }] }]; }
+};
+export default nextConfig;

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,3 @@
+import { NextResponse } from "next/server";
+
+export const GET = () => NextResponse.json({ status: "ok" });

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,0 +1,15 @@
+export const metadata = {
+	title: 'App',
+	description: 'App Layout',
+};
+
+export default function RootLayout({ children }: { children: React.ReactNode }) {
+	return (
+		<html lang="en">
+			<head>
+				<link rel="stylesheet" href="/styles.css" />
+			</head>
+			<body>{children}</body>
+		</html>
+	);
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,0 +1,16 @@
+export default function Page() {
+	return (
+		<>
+			<header className="px-4 py-5">
+				<div className="mx-auto max-w-6xl flex items-center gap-4">
+					<a href="#" className="text-2xl font-bold gold-text">NØID</a>
+					<nav className="ml-auto flex items-center gap-5 md:gap-8 text-sm sm:text-base md:text-lg whitespace-nowrap">
+						<a href="#features" className="hover:text-teal-400">Features</a>
+						<a href="#dashboard" className="hover:text-teal-400">Dashboard</a>
+						<a href="#founder" className="hover:text-teal-400">Founder</a>
+					</nav>
+				</div>
+			</header>
+		</>
+	);
+}


### PR DESCRIPTION
Introduce Next.js App Router structure, add `/api/health` endpoint, and normalize `next.config.mjs` to prepare for clean Vercel deployments and CI/CD.

---
<a href="https://cursor.com/background-agent?bcId=bc-f7ed2936-5fe8-47c8-aeb5-fd782ead6278">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f7ed2936-5fe8-47c8-aeb5-fd782ead6278">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

