### PR TITLE
Fix recurring cursor bug permanently

### DIFF
--- a/.github/workflows/preview-smoke.yml
+++ b/.github/workflows/preview-smoke.yml
@@ -1,0 +1,70 @@
+name: PR Preview Smoke
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  preview-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up job
+        run: echo "Starting preview smoke"
+
+      - name: Checkout
+        uses: actions/checkout@v4
+        with: { fetch-depth: 0 }
+
+      - name: Install dependencies
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+      - run: npm ci
+
+      - name: Determine PR branch
+        id: pr
+        run: |
+          echo "number=${{ github.event.pull_request.number }}" >> $GITHUB_OUTPUT
+          echo "ref=${{ github.head_ref }}" >> $GITHUB_OUTPUT
+
+      - name: Fetch latest Vercel preview URL
+        id: fetch
+        env:
+          VERCEL_TOKEN: ${{ secrets.VERCEL_TOKEN }}
+          VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+          VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+          PR_NUMBER: ${{ steps.pr.outputs.number }}
+        run: node automation/fetch-vercel-preview.js
+
+      - name: Run preview smoke
+        if: ${{ steps.fetch.conclusion == 'success' }}
+        run: bash tests/smoke/health.spec.sh "${{ steps.fetch.outputs.url }}"
+
+      - name: Comment result
+        if: always()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request?.number;
+            if (!pr) { core.info('No PR context; skipping comment.'); return; }
+            const url = `${{ toJSON(steps.fetch.outputs.url || '') }}`;
+            const success = `${{ job.status }}` === 'success';
+            const body = success
+              ? `✅ Preview smoke passed\nURL: ${url}`
+              : `❌ Preview smoke failed\nURL: ${url || 'N/A'}`;
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: pr,
+              body,
+            });
+
+      - name: Fail if smoke failed
+        if: failure()
+        run: exit 1

--- a/automation/fetch-vercel-preview.js
+++ b/automation/fetch-vercel-preview.js
@@ -1,0 +1,104 @@
+const https = require('https');
+
+const { VERCEL_TOKEN, GITHUB_REPOSITORY, GITHUB_REF_NAME, PR_NUMBER } = process.env;
+
+function fail(message) {
+	console.error(message);
+	process.exit(1);
+}
+
+if (!VERCEL_TOKEN) fail('Missing VERCEL_TOKEN');
+
+// Determine PR number reliably
+const prNumber = PR_NUMBER || (GITHUB_REF_NAME && GITHUB_REF_NAME.replace(/^[^0-9]+/, '')) || '';
+
+function api(path) {
+	const options = {
+		hostname: 'api.vercel.com',
+		path,
+		method: 'GET',
+		headers: { Authorization: `Bearer ${VERCEL_TOKEN}` }
+	};
+	return new Promise((resolve, reject) => {
+		const req = https.request(options, (res) => {
+			let data = '';
+			res.on('data', (chunk) => (data += chunk));
+			res.on('end', () => {
+				if (res.statusCode && res.statusCode >= 200 && res.statusCode < 300) {
+					try {
+						resolve(JSON.parse(data));
+					} catch (e) {
+						reject(new Error('Failed to parse Vercel API response'));
+					}
+				} else {
+					reject(new Error(`Vercel API ${res.statusCode}: ${data}`));
+				}
+			});
+		});
+		req.on('error', reject);
+		req.end();
+	});
+}
+
+async function sleep(ms) {
+	return new Promise((r) => setTimeout(r, ms));
+}
+
+async function fetchLatestPreviewUrlWithRetries({ projectId, orgId, maxAttempts = 10, baseDelayMs = 3000 }) {
+	let attempt = 0;
+	let lastError = null;
+	while (attempt < maxAttempts) {
+		attempt += 1;
+		try {
+			// Vercel deployments list
+			const query = new URLSearchParams({ projectId, teamId: orgId, limit: '20' }).toString();
+			const res = await api(`/v6/deployments?${query}`);
+			const deployments = Array.isArray(res.deployments) ? res.deployments : res;
+
+			// Filter preview deployments linked to this PR if PR number is available
+			const candidates = deployments.filter((d) => {
+				const isPreview = d?.target === 'preview' || d?.meta?.githubCommitRef?.startsWith('refs/pull/');
+				const prMatch = prNumber
+					? (d?.meta?.githubPrNumber && String(d.meta.githubPrNumber) === String(prNumber))
+					: true;
+				return isPreview && prMatch;
+			});
+
+			// Sort by created descending
+			candidates.sort((a, b) => (b?.createdAt || 0) - (a?.createdAt || 0));
+			const latest = candidates[0] || deployments[0];
+			if (!latest) throw new Error('No deployments found yet');
+
+			const alias = latest?.alias || latest?.aliases || latest?.readyState === 'READY' ? latest?.url : null;
+			const url = typeof alias === 'string' ? `https://${alias}` : latest?.url ? `https://${latest.url}` : null;
+			if (!url) throw new Error('Deployment exists but missing URL');
+
+			return { url, deploymentId: latest.uid || latest.id, readyState: latest.readyState };
+		} catch (err) {
+			lastError = err;
+			const delay = baseDelayMs * Math.pow(1.5, attempt - 1);
+			console.log(`Attempt ${attempt} failed: ${err.message}. Retrying in ${Math.round(delay)}ms...`);
+			await sleep(delay);
+		}
+	}
+	throw lastError || new Error('Unknown error fetching preview URL');
+}
+
+(async () => {
+	try {
+		const projectId = process.env.VERCEL_PROJECT_ID;
+		const orgId = process.env.VERCEL_ORG_ID;
+		if (!projectId || !orgId) fail('Missing VERCEL_PROJECT_ID or VERCEL_ORG_ID');
+		const result = await fetchLatestPreviewUrlWithRetries({ projectId, orgId });
+		console.log(`Preview URL: ${result.url}`);
+		// GitHub Actions output
+		if (process.env.GITHUB_OUTPUT) {
+			const fs = require('fs');
+			fs.appendFileSync(process.env.GITHUB_OUTPUT, `url=${result.url}\n`);
+		}
+		process.exit(0);
+	} catch (e) {
+		console.error('Failed to fetch Vercel preview URL:', e.message);
+		process.exit(1);
+	}
+})();


### PR DESCRIPTION
Add a new GitHub Actions workflow and script to reliably fetch Vercel preview URLs with retries and a health check.

The previous method of fetching Vercel preview URLs was prone to flakiness due to API timing issues and deployments not being immediately available. This PR introduces a dedicated Node.js script that uses exponential backoff and retries to ensure the latest preview URL is successfully retrieved, followed by a basic health check to confirm the deployment is ready.

---
<a href="https://cursor.com/background-agent?bcId=bc-d046f711-7161-48dd-8e97-e22de6d26bc7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d046f711-7161-48dd-8e97-e22de6d26bc7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

