### PR TITLE
Setup codespaces devcontainer and readme

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+  "name": "luxgrid-ui",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:20",
+  "postCreateCommand": "npm ci",
+  "forwardPorts": [3000],
+  "customizations": {
+    "vscode": {
+      "settings": {
+        "editor.formatOnSave": true
+      },
+      "extensions": [
+        "dbaeumer.vscode-eslint",
+        "esbenp.prettier-vscode"
+      ]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -37,3 +37,11 @@ LuxGrid UI provides Fortune-500 polish, accessibility, and modular components ac
 ---
 
 © 2025 LuxGrid — MIT License
+
+## 🚀 Cloud Dev (Codespaces)
+1. Click **Code → Codespaces → Create codespace**.
+2. It opens VS Code in the browser, runs `npm ci` automatically.
+3. Run `npm run dev` — a URL will appear (port 3000 forwarded).
+4. Open that URL and verify:
+   - `/` renders the NØID landing page (not blank)
+   - `/api/health` returns `{"status":"ok"}`


### PR DESCRIPTION
Add GitHub Codespaces devcontainer and README instructions to provide a consistent cloud development environment for guaranteed visual preview.

---
<a href="https://cursor.com/background-agent?bcId=bc-748e2df5-459f-4f96-bbb1-9f67f9c945c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-748e2df5-459f-4f96-bbb1-9f67f9c945c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

