### PR TITLE
Add netlify fallback preview workflow

### DIFF
--- a/.github/workflows/netlify-preview.yml
+++ b/.github/workflows/netlify-preview.yml
@@ -1,0 +1,58 @@
+name: Netlify Preview (fallback)
+on:
+  workflow_dispatch:
+  push:
+    branches:
+      - fix/minimal-deploy
+      - netlify-preview
+jobs:
+  preview:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    env:
+      NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
+      NETLIFY_SITE_ID:    ${{ secrets.NETLIFY_SITE_ID }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install
+        run: npm ci
+
+      - name: Build (Next.js)
+        run: npm run build
+
+      # Netlify will auto-detect Next.js and package SSR correctly.
+      - name: Deploy to Netlify (preview)
+        run: npx netlify-cli deploy --build --message "Preview from GitHub Actions" --json > netlify.json
+
+      - name: Extract Preview URL
+        id: extract
+        run: |
+          PREVIEW_URL=$(cat netlify.json | node -e "process.stdout.write(JSON.parse(require('fs').readFileSync(0,'utf8')).deploy_url || '')")
+          echo "url=$PREVIEW_URL" >> $GITHUB_OUTPUT
+          echo "Preview URL: $PREVIEW_URL"
+
+      - name: Comment PR with Preview URL
+        if: ${{ github.event_name == 'push' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const url = '${{ steps.extract.outputs.url }}';
+            if (!url) {
+              core.setFailed('No Netlify preview URL found.');
+            } else if (context.payload.pull_request) {
+              await github.rest.issues.createComment({
+                issue_number: context.payload.pull_request.number,
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                body: `🟢 Netlify preview is ready: ${url}`
+              });
+            } else {
+              core.info(`Preview URL: ${url}`);
+            }

--- a/README.md
+++ b/README.md
@@ -37,3 +37,9 @@ LuxGrid UI provides Fortune-500 polish, accessibility, and modular components ac
 ---
 
 © 2025 LuxGrid — MIT License
+
+## 🧪 Netlify Fallback Preview
+If Vercel is noisy, trigger a backup preview:
+1) Add two GitHub Secrets: **NETLIFY_AUTH_TOKEN** and **NETLIFY_SITE_ID** (from Netlify dashboard).
+2) Run **Actions → Netlify Preview (fallback) → Run workflow** on your branch.
+3) The job prints a **Preview URL** you can open and share (works with SSR).

--- a/netlify.toml
+++ b/netlify.toml
@@ -1,0 +1,3 @@
+[build]
+  command = "npm run build"
+


### PR DESCRIPTION
Add a Netlify preview fallback workflow to provide a temporary, parallel live URL for visual verification and analysis.

This workflow creates a Netlify deployment that runs independently of the existing Vercel setup, offering a reliable preview link for testing and sharing without affecting the primary deployment. It also includes a minimal `netlify.toml` and updates the `README.md` with instructions on how to trigger it.

---
<a href="https://cursor.com/background-agent?bcId=bc-b2e744b6-c461-40ae-bdc5-248b2fe60f91">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b2e744b6-c461-40ae-bdc5-248b2fe60f91">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

