### PR TITLE
Link, deploy, and get production url

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -21,11 +21,7 @@
     }
   ],
   "cleanUrls": true,
-  "trailingSlash": false
-}
-
-{
-  "framework": null,
+  "trailingSlash": false,
   "buildCommand": "",
   "installCommand": "",
   "outputDirectory": "public"


### PR DESCRIPTION
Fix malformed `vercel.json` to enable Vercel linking and deployment.

The `vercel.json` file contained two root JSON objects, causing a syntax error that prevented Vercel commands from executing successfully. This change merges the configuration into a single, valid JSON structure.

---
<a href="https://cursor.com/background-agent?bcId=bc-0b486b99-944a-46a9-b603-3f9e3c0cc6c9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0b486b99-944a-46a9-b603-3f9e3c0cc6c9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

